### PR TITLE
Add streaming interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 'use strict';
-module.exports = function (str) {
-	if (typeof str !== 'string') {
-		throw new TypeError('Expected a string');
-	}
+var through = require('through2');
 
+function stripCssComments(str) {
 	var currentChar = '';
 	var insideString = false;
 	var ret = '';
@@ -38,4 +36,19 @@ module.exports = function (str) {
 	}
 
 	return ret;
+}
+
+module.exports = function (str) {
+	if (str && typeof str !== 'string') {
+		throw new TypeError('Expected a string');
+	}
+
+	if (str) {
+		return stripCssComments(str);
+	}
+
+	return through(function (data, enc, cb) {
+		var ret = stripCssComments(data.toString());
+		cb(null, new Buffer(ret));
+	});
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   ],
   "dependencies": {
     "get-stdin": "^3.0.0",
-    "meow": "^2.0.0"
+    "meow": "^2.0.0",
+    "through2": "^0.6.3"
   },
   "devDependencies": {
     "ava": "0.0.4",

--- a/test.js
+++ b/test.js
@@ -12,3 +12,27 @@ test(function (t) {
 	t.assert(strip('body{/*"\'\\"*/}') === 'body{}');
 	t.end();
 });
+
+test(function (t) {
+	var stream = strip();
+	var ret = '';
+
+	stream.on('data', function (data) {
+		ret += data.toString();
+	});
+
+	stream.on('end', function () {
+		var css = 'body{}body{}body{}body{content: "\'/*ad*/\' \\""}body{\r\n \n}body{}body{}';
+		t.assert(ret === css);
+		t.end();
+	});
+
+	stream.write('/*//comment*/body{}');
+	stream.write('body{/*comment*/}');
+	stream.write('body{/*\ncomment\n\\*/}');
+	stream.write('body{content: "\'/*ad*/\' \\""}');
+	stream.write('body{\r\n /*\n\n\n\nfoo*/\n}');
+	stream.write('body/*foo*/{}');
+	stream.write('body{/*"\'\\"*/}');
+	stream.end();
+});


### PR DESCRIPTION
Exports `.stream()` to use as stream. Was going to add it to the benchmark suite but it throws `EMFILE` so probably not worth it.

Fixes #5.
