### PR TITLE
Preserve "important" CSS comments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,13 +25,7 @@ var cli = meow({
 });
 
 function init(data) {
-	var options = {};
-
-	if (cli.flags.hasOwnProperty('all')) {
-		options.preserve = !cli.flags.all;
-	}
-
-	console.log(stripCssComments(data, options));
+	console.log(stripCssComments(data, cli.flags));
 }
 
 if (process.stdin.isTTY) {

--- a/cli.js
+++ b/cli.js
@@ -11,15 +11,27 @@ var cli = meow({
 		'  strip-css-comments <input-file> > <output-file>',
 		'  strip-css-comments < <input-string>',
 		'',
+		'Option',
+		'  -a, --all strip all comments without any exceptions',
+		'',
 		'Example',
-		'  strip-css-comments src/app.css > dist/app.css'
+		'  strip-css-comments src/app.css > dist/app.css',
+		'  strip-css-comments < src/app.css --all'
 	].join('\n')
 }, {
-	string: ['_']
+	string: ['_'],
+	boolean: ['all'],
+	alias: {'all': 'a'}
 });
 
 function init(data) {
-	console.log(stripCssComments(data));
+	var options = {};
+
+	if (cli.flags.hasOwnProperty('all')) {
+		options.preserve = !cli.flags.all;
+	}
+
+	console.log(stripCssComments(data, options));
 }
 
 if (process.stdin.isTTY) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function (str, options) {
 
 	options = options || {};
 
-	var preserve = options.hasOwnProperty('preserve') ? !!options.preserve : true;
+	var preserve = !options.all;
 	var currentChar = '';
 	var insideString = false;
 	var ret = '';

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 'use strict';
-module.exports = function (str) {
+module.exports = function (str, options) {
 	if (typeof str !== 'string') {
 		throw new TypeError('Expected a string');
 	}
 
+	options = options || {};
+
+	var preserve = options.hasOwnProperty('preserve') ? !!options.preserve : true;
 	var currentChar = '';
 	var insideString = false;
 	var ret = '';
@@ -23,15 +26,17 @@ module.exports = function (str) {
 
 		// start /* type comment
 		if (!insideString && currentChar + str[i + 1] === '/*') {
-			// start skipping until we reach end of comment
-			for (var j = i + 2; j < str.length; j++) {
-				if (str[j] + str[j + 1] === '*/') {
-					break;
+			if (!preserve || preserve && str[i + 2] !== '!') {
+				// start skipping until we reach end of comment
+				for (var j = i + 2; j < str.length; j++) {
+					if (str[j] + str[j + 1] === '*/') {
+						break;
+					}
 				}
+				// skip i to the end of the comment
+				i = j + 1;
+				continue;
 			}
-			// skip i to the end of the comment
-			i = j + 1;
-			continue;
 		}
 
 		ret += currentChar;

--- a/readme.md
+++ b/readme.md
@@ -35,17 +35,17 @@ stripCssComments('body { /* unicorns */color: hotpink; }');
 
 All options are optionals and set up with usable defaults. Change them according to your needs.
 
-### `preserve`
+### `all`
 
-`Boolean` indicates if "important" CSS comments (beginning with the characters `/*!`) should be preserved in the output.
+`Boolean` indicates if "important" CSS comments (beginning with the characters `/*!`) should be also striped in the output.
 
-Default value is `true`.
+Default value is `false`.
 
 ```js
 stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
 //=> /*! <copyright> */ body { color: hotpink; }
 
-stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }', {preserve: false});
+stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }', {all: true});
 //=> body { color: hotpink; }
 ``` 
 

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,40 @@ $ npm install --save strip-css-comments
 ```js
 var stripCssComments = require('strip-css-comments');
 
+stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
+
+```
+
+
+## API
+
+### `stripCssComments(input[, options])`
+
+Returns a `String` without any CSS comments according to the options described below.
+
+```js
 stripCssComments('body { /* unicorns */color: hotpink; }');
 //=> body { color: hotpink; }
-```
+``` 
+
+
+## Options
+
+All options are optionals and set up with usable defaults. Change them according to your needs.
+
+### `preserve`
+
+`Boolean` indicates if "important" CSS comments (beginning with the characters `/*!`) should be preserved in the output.
+
+Default value is `true`.
+
+```js
+stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
+//=> /*! <copyright> */ body { color: hotpink; }
+
+stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }', {preserve: false});
+//=> body { color: hotpink; }
+``` 
 
 
 ## CLI
@@ -32,8 +63,12 @@ $ strip-css-comments --help
     strip-css-comments <input-file> > <output-file>
     strip-css-comments < <input-string>
 
+  Option
+  	-a, --all strip all comments without any exceptions
+
   Example
     strip-css-comments src/app.css > dist/app.css
+    strip-css-comments < src/app.css --all
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -19,13 +19,13 @@ test(function (t) {
 	t.assert(strip('body/*!foo*/{}') === 'body/*!foo*/{}');
 	t.assert(strip('body{/*!"\'\\"*/}') === 'body{/*!"\'\\"*/}');
 
-	t.assert(strip('/*!//comment*/body{}', {preserve: false}) === 'body{}');
-	t.assert(strip('body{/*!comment*/}', {preserve: false}) === 'body{}');
-	t.assert(strip('body{/*!\ncomment\n\\*/}', {preserve: false}) === 'body{}');
-	t.assert(strip('body{content: "\'/*!ad*/\' \\""}', {preserve: false}) === 'body{content: "\'/*!ad*/\' \\""}');
-	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}', {preserve: false}) === 'body{\r\n \n}');
-	t.assert(strip('body/*!foo*/{}', {preserve: false}) === 'body{}');
-	t.assert(strip('body{/*!"\'\\"*/}', {preserve: false}) === 'body{}');
+	t.assert(strip('/*!//comment*/body{}', {all: true}) === 'body{}');
+	t.assert(strip('body{/*!comment*/}', {all: true}) === 'body{}');
+	t.assert(strip('body{/*!\ncomment\n\\*/}', {all: true}) === 'body{}');
+	t.assert(strip('body{content: "\'/*!ad*/\' \\""}', {all: true}) === 'body{content: "\'/*!ad*/\' \\""}');
+	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}', {all: true}) === 'body{\r\n \n}');
+	t.assert(strip('body/*!foo*/{}', {all: true}) === 'body{}');
+	t.assert(strip('body{/*!"\'\\"*/}', {all: true}) === 'body{}');
 
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -10,5 +10,22 @@ test(function (t) {
 	t.assert(strip('body{\r\n /*\n\n\n\nfoo*/\n}') === 'body{\r\n \n}');
 	t.assert(strip('body/*foo*/{}') === 'body{}');
 	t.assert(strip('body{/*"\'\\"*/}') === 'body{}');
+
+	t.assert(strip('/*!//comment*/body{}') === '/*!//comment*/body{}');
+	t.assert(strip('body{/*!comment*/}') === 'body{/*!comment*/}');
+	t.assert(strip('body{/*!\ncomment\n\\*/}') === 'body{/*!\ncomment\n\\*/}');
+	t.assert(strip('body{content: "\'/*!ad*/\' \\""}') === 'body{content: "\'/*!ad*/\' \\""}');
+	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}') === 'body{\r\n /*!\n\n\n\nfoo*/\n}');
+	t.assert(strip('body/*!foo*/{}') === 'body/*!foo*/{}');
+	t.assert(strip('body{/*!"\'\\"*/}') === 'body{/*!"\'\\"*/}');
+
+	t.assert(strip('/*!//comment*/body{}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{/*!comment*/}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{/*!\ncomment\n\\*/}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{content: "\'/*!ad*/\' \\""}', {preserve: false}) === 'body{content: "\'/*!ad*/\' \\""}');
+	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}', {preserve: false}) === 'body{\r\n \n}');
+	t.assert(strip('body/*!foo*/{}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{/*!"\'\\"*/}', {preserve: false}) === 'body{}');
+
 	t.end();
 });


### PR DESCRIPTION
According to the issue https://github.com/sindresorhus/strip-css-comments/issues/4 by @terribleplan,  here are the changes to preserve the "important" CSS comments (beginning with the characters `/*!`) in the output and to allow the users to change this new behaviour by setting the option `preserve` to `false` or by using the option `--all` in CLI to strip all comments without any exceptions.

I hope you will like this PR :blush: