### PR TITLE
Add filter option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (str, opts) {
 	var currentChar = '';
 	var insideString = false;
 
-	var filter = !!(opts.filter && opts.filter.constructor && opts.filter.call && opts.filter.apply);
+	var filter = typeof opts.filter === 'function';
 	var filtering = false;
 	
 	var comment = '';
@@ -29,10 +29,10 @@ module.exports = function (str, opts) {
 		// start /* type comment
 		if (!insideString && currentChar + str[i + 1] === '/*') {
 			if (!preserve || preserve && str[i + 2] !== '!') {
-				// start skipping until we reach end of comment
+				// process comment
 				for (var j = i + 2; j < str.length; j++) {
 					if (str[j] + str[j + 1] === '*/') {
-						if (filtering){
+						if (filtering) {
 							filtering = false;
 							ret = opts.filter(comment) ? ret : ret += ('/*' + comment + '*/'); 
 							comment = '';                    
@@ -52,7 +52,9 @@ module.exports = function (str, opts) {
 			}
 		}
 
-		if (!filtering){ret += currentChar;}
+		if (!filtering) {
+			ret += currentChar;
+		}
 	}
 
 	return ret;

--- a/index.js
+++ b/index.js
@@ -7,20 +7,18 @@ module.exports = function (str, opts) {
 	var currentChar = '';
 	var insideString = false;
 	var preserveFilter;
-	var preserveImportant = (opts.preserve === false || opts.all === true) ? false : true;
+	var preserveImportant = !(opts.preserve === false || opts.all === true);
 	var ret = '';
 
-	//use preserveFilter as an interface for opts.preserve function and RegExp values
-	if (opts !== undefined && opts.preserve !== undefined) {
-		if ((typeof opts.preserve).toLowerCase() === 'function') {
-			preserveImportant = false;
-			preserveFilter = opts.preserve;
-		} else if ((opts.preserve.constructor.name).toLowerCase() === 'regexp') {
-			preserveImportant = false;
-			preserveFilter = function (comment) {
-				return opts.preserve.test(comment);
-			};
-		}
+	// use preserveFilter as an interface for opts.preserve function and RegExp valuess
+	if (typeof opts.preserve === 'function') {
+		preserveImportant = false;
+		preserveFilter = opts.preserve;
+	} else if (opts.preserve instanceof RegExp) {
+		preserveImportant = false;
+		preserveFilter = function (comment) {
+			return opts.preserve.test(comment);
+		};
 	}
 
 	for (var i = 0; i < str.length; i++) {
@@ -36,29 +34,29 @@ module.exports = function (str, opts) {
 			}
 		}
 
-		//find beginning of /* type comment
+		// find beginning of /* type comment
 		if (!insideString && currentChar === '/' && str[i + 1] === '*') {
-			//ignore important comment when configured to preserve comments using important syntax: /*!
+			// ignore important comment when configured to preserve comments using important syntax: /*!
 			if (!(preserveImportant && str[i + 2] === '!')) {
 				// iterate over comment
 				for (var j = i + 2; j < str.length; j++) {
-					//find end of comment
+					// find end of comment
 					if (str[j] === '*' && str[j + 1] === '/') {
 						if (preserveFilter) {
 							//evaluate comment text
-							ret = preserveFilter(comment) ? ret += ('/*' + comment + '*/') : ret;
+							ret = preserveFilter(comment) ? ret + ('/*' + comment + '*/') : ret;
 							comment = '';
 						}
 
 						break;
 					}
 
-					//store comment text to be evaluated by the filter when the end of the comment is reached
+					// store comment text to be evaluated by the filter when the end of the comment is reached
 					if (preserveFilter) {
 						comment += str[j];
 					}
 				}
-				//resume iteration over CSS string from the end of the comment
+				// resume iteration over CSS string from the end of the comment
 				i = j + 1;
 				continue;
 			}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ module.exports = function (str, opts) {
 	var preserve = !opts.all;
 	var currentChar = '';
 	var insideString = false;
+
+    var filter = !!(opts.filter && opts.filter.constructor && opts.filter.call && opts.filter.apply);
+    var filtering = false;
+    
+    var comment = '';
 	var ret = '';
 
 	for (var i = 0; i < str.length; i++) {
@@ -26,9 +31,20 @@ module.exports = function (str, opts) {
 			if (!preserve || preserve && str[i + 2] !== '!') {
 				// start skipping until we reach end of comment
 				for (var j = i + 2; j < str.length; j++) {
-					if (str[j] + str[j + 1] === '*/') {
-						break;
-					}
+                    if (str[j] + str[j + 1] === '*/') {
+                        if (filtering){
+                            filtering = false;
+                            ret = opts.filter(comment) ? ret : ret += ('/*' + comment + '*/'); 
+                            comment = '';                    
+                        }
+
+                        break;
+                    }
+
+                    if (filter) {
+                        filtering = true;
+                        comment += str[j];
+                    }
 				}
 				// skip i to the end of the comment
 				i = j + 1;
@@ -36,7 +52,7 @@ module.exports = function (str, opts) {
 			}
 		}
 
-		ret += currentChar;
+        if (!filtering){ret += currentChar;}
 	}
 
 	return ret;

--- a/index.js
+++ b/index.js
@@ -7,10 +7,10 @@ module.exports = function (str, opts) {
 	var currentChar = '';
 	var insideString = false;
 
-    var filter = !!(opts.filter && opts.filter.constructor && opts.filter.call && opts.filter.apply);
-    var filtering = false;
-    
-    var comment = '';
+	var filter = !!(opts.filter && opts.filter.constructor && opts.filter.call && opts.filter.apply);
+	var filtering = false;
+	
+	var comment = '';
 	var ret = '';
 
 	for (var i = 0; i < str.length; i++) {
@@ -31,20 +31,20 @@ module.exports = function (str, opts) {
 			if (!preserve || preserve && str[i + 2] !== '!') {
 				// start skipping until we reach end of comment
 				for (var j = i + 2; j < str.length; j++) {
-                    if (str[j] + str[j + 1] === '*/') {
-                        if (filtering){
-                            filtering = false;
-                            ret = opts.filter(comment) ? ret : ret += ('/*' + comment + '*/'); 
-                            comment = '';                    
-                        }
+					if (str[j] + str[j + 1] === '*/') {
+						if (filtering){
+							filtering = false;
+							ret = opts.filter(comment) ? ret : ret += ('/*' + comment + '*/'); 
+							comment = '';                    
+						}
 
-                        break;
-                    }
+						break;
+					}
 
-                    if (filter) {
-                        filtering = true;
-                        comment += str[j];
-                    }
+					if (filter) {
+						filtering = true;
+						comment += str[j];
+					}
 				}
 				// skip i to the end of the comment
 				i = j + 1;
@@ -52,7 +52,7 @@ module.exports = function (str, opts) {
 			}
 		}
 
-        if (!filtering){ret += currentChar;}
+		if (!filtering){ret += currentChar;}
 	}
 
 	return ret;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 'use strict';
+var isRegExp = require('is-regexp');
+
 module.exports = function (str, opts) {
 	str = str.toString();
 	opts = opts || {};
@@ -14,7 +16,7 @@ module.exports = function (str, opts) {
 	if (typeof opts.preserve === 'function') {
 		preserveImportant = false;
 		preserveFilter = opts.preserve;
-	} else if (opts.preserve instanceof RegExp) {
+	} else if (isRegExp(opts.preserve)) {
 		preserveImportant = false;
 		preserveFilter = function (comment) {
 			return opts.preserve.test(comment);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "dependencies": {
     "get-stdin": "^4.0.1",
+    "is-regexp": "^1.0.0",
     "meow": "^3.3.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,10 @@ stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
 // use the `all: true` option to strip everything
 stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }', {all: true});
 //=> ' body { color: hotpink; }'
+
+// use the `filter: function(comment){...}`
+stripCssComments('/* unicorns */ body {/*##unicorns##*/ color: hotpink; }', {filter: function(comment){return /^##unicorns##/.test(comment);}});
+//=> '/* unicorns */ body { color: hotpink; }'
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
 stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }', {all: true});
 //=> ' body { color: hotpink; }'
 
-// use the `filter: function(comment){...}`
+// use the `filter: function(comment){...}` to selectively strip comments
 stripCssComments('/* unicorns */ body {/*##unicorns##*/ color: hotpink; }', {filter: function(comment){return /^##unicorns##/.test(comment);}});
 //=> '/* unicorns */ body { color: hotpink; }'
 ```

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,12 @@ Default: `false`
 
 Whether *important* CSS comments *(those starting with `/*!`)* should be stripped.
 
+### filter
+
+Type: `function`  
+Default: `undefined`
+
+A function that gets the comment contents and returns a boolean whether to strip the comment. If `true`, the comment is stripped. If `false`, the comment is preserved.
 
 ## CLI
 

--- a/readme.md
+++ b/readme.md
@@ -28,18 +28,19 @@ stripCssComments(
 //assign the preserve option a regular expression to strip comments not matching the pattern
 stripCssComments(
 	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
-	{preserve: /^\\!/}
+	{preserve: /^\!/}
 );
 //=> '/*! <copyright> */ body { color: hotpink; }'
 
 //assign the preserve option a function that returns `true` to preserve the comment or `false` to strip the comment
 stripCssComments(
 	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
-	{preserve: function(comment){/^\\!/.test(comment);}}
+	{preserve: function(comment){/^\!/.test(comment);}}
 );
 //=> '/*! <copyright> */ body { color: hotpink; }'
 
 ```
+
 
 ## API
 
@@ -52,7 +53,6 @@ Type: `string`
 
 String with CSS.
 
-
 ## options
 
 ### preserve
@@ -60,10 +60,10 @@ String with CSS.
 Type: `boolean`, `RegExp`, or `function` 
 Default: `true`
 
-- `preserve: true` &mdash; (default) preserve comments that use the `/*! */` syntax;
-- `preserve: false` &mdash; strip all comments;
-- `preserve: [RegExp]` &mdash; preserve comments that match a regular expression. The comment text but not the comment syntax (`/**/`) will be tested by the RegExp.
-- `preserve: function (comment) { ... }` &mdash; a function that returns `true` to preserve the comment or `false` to strip it. The comment is invoked with a single argument, the string found between the comment syntax, `/**/`.
+- `preserve: true` - (default) preserve comments that use the `/*! */` syntax;
+- `preserve: false` - strip all comments;
+- `preserve: [RegExp]` - preserve comments that match a regular expression. The comment text but not the comment syntax (`/**/`) will be tested by the RegExp.
+- `preserve: function (comment) { ... }` - a function that returns `true` to preserve the comment or `false` to strip it. The comment is invoked with a single argument, the string found between the comment syntax, `/**/`.
 
 
 ## CLI
@@ -75,23 +75,25 @@ $ npm install --global strip-css-comments
 ```
 $ strip-css-comments --help
 
-  Usage
-    $ strip-css-comments <input-file> > <output-file>
-    $ strip-css-comments < <input-string>
+	Usage
+		$ strip-css-comments <input-file> > <output-file>
+		$ strip-css-comments < <input-string>
 
-  Option
-    -a, --all  Strip all comments including `/*!`
+	Option
+		-a, --all  Strip all comments including `/*!`
 
-  Example
-    $ strip-css-comments src/app.css > dist/app.css
-    $ strip-css-comments < src/app.css --all
+	Example
+		$ strip-css-comments src/app.css > dist/app.css
+		$ strip-css-comments < src/app.css --all
 ```
+
 
 ## Benchmark
 
 ```
 $ npm run bench
 ```
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -18,27 +18,26 @@ var stripCssComments = require('strip-css-comments');
 stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
 //=> '/*! <copyright> */ body { color: hotpink; }'
 
-//assign the preserve option `false` to strip all comments including `/*!`
+// assign the preserve option `false` to strip all comments including `/*!`
 stripCssComments(
-	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
-	{preserve: false}
+  '/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
+  {preserve: false}
 );
 //=> 'body { color: hotpink; }'
 
-//assign the preserve option a regular expression to strip comments not matching the pattern
+// assign the preserve option a regular expression to strip comments not matching the pattern
 stripCssComments(
-	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
-	{preserve: /^\!/}
+  '/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
+  {preserve: /^\!/}
 );
 //=> '/*! <copyright> */ body { color: hotpink; }'
 
-//assign the preserve option a function that returns `true` to preserve the comment or `false` to strip the comment
+// assign the preserve option a function that returns `true` to preserve the comment or `false` to strip the comment
 stripCssComments(
-	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
-	{preserve: function(comment){/^\!/.test(comment);}}
+  '/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
+  {preserve: function(comment){/^\!/.test(comment);}}
 );
 //=> '/*! <copyright> */ body { color: hotpink; }'
-
 ```
 
 
@@ -57,13 +56,13 @@ String with CSS.
 
 ### preserve
 
-Type: `boolean`, `RegExp`, or `function` 
+Type: `boolean`, `RegExp`, or `function`  
 Default: `true`
 
 - `preserve: true` - (default) preserve comments that use the `/*! */` syntax;
 - `preserve: false` - strip all comments;
 - `preserve: [RegExp]` - preserve comments that match a regular expression. The comment text but not the comment syntax (`/**/`) will be tested by the RegExp.
-- `preserve: function (comment) { ... }` - a function that returns `true` to preserve the comment or `false` to strip it. The comment is invoked with a single argument, the string found between the comment syntax, `/**/`.
+- `preserve: function (comment) { ... }` - a function that returns `true` to preserve the comment or `false` to strip it. The comment is invoked with a single argument, the string found between the comment syntax (`/**/`).
 
 
 ## CLI
@@ -75,16 +74,16 @@ $ npm install --global strip-css-comments
 ```
 $ strip-css-comments --help
 
-	Usage
-		$ strip-css-comments <input-file> > <output-file>
-		$ strip-css-comments < <input-string>
+  Usage
+    $ strip-css-comments <input-file> > <output-file>
+    $ strip-css-comments < <input-string>
 
-	Option
-		-a, --all  Strip all comments including `/*!`
+  Option
+    -a, --all  Strip all comments including `/*!`
 
-	Example
-		$ strip-css-comments src/app.css > dist/app.css
-		$ strip-css-comments < src/app.css --all
+  Example
+    $ strip-css-comments src/app.css > dist/app.css
+    $ strip-css-comments < src/app.css --all
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -18,15 +18,28 @@ var stripCssComments = require('strip-css-comments');
 stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }');
 //=> '/*! <copyright> */ body { color: hotpink; }'
 
-// use the `all: true` option to strip everything
-stripCssComments('/*! <copyright> */ body { /* unicorns */color: hotpink; }', {all: true});
-//=> ' body { color: hotpink; }'
+//assign the preserve option `false` to strip all comments including `/*!`
+stripCssComments(
+	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
+	{preserve: false}
+);
+//=> 'body { color: hotpink; }'
 
-// use the `filter: function(comment){...}` to selectively strip comments
-stripCssComments('/* unicorns */ body {/*##unicorns##*/ color: hotpink; }', {filter: function(comment){return /^##unicorns##/.test(comment);}});
-//=> '/* unicorns */ body { color: hotpink; }'
+//assign the preserve option a regular expression to strip comments not matching the pattern
+stripCssComments(
+	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
+	{preserve: /^\\!/}
+);
+//=> '/*! <copyright> */ body { color: hotpink; }'
+
+//assign the preserve option a function that returns `true` to preserve the comment or `false` to strip the comment
+stripCssComments(
+	'/*! <copyright> */ body { /* unicorns */color: hotpink; }', 
+	{preserve: function(comment){/^\\!/.test(comment);}}
+);
+//=> '/*! <copyright> */ body { color: hotpink; }'
+
 ```
-
 
 ## API
 
@@ -39,21 +52,19 @@ Type: `string`
 
 String with CSS.
 
+
 ## options
 
-### all
+### preserve
 
-Type: `boolean`  
-Default: `false`
+Type: `boolean`, `RegExp`, or `function` 
+Default: `true`
 
-Whether *important* CSS comments *(those starting with `/*!`)* should be stripped.
+- `preserve: true` &mdash; (default) preserve comments that use the `/*! */` syntax;
+- `preserve: false` &mdash; strip all comments;
+- `preserve: [RegExp]` &mdash; preserve comments that match a regular expression. The comment text but not the comment syntax (`/**/`) will be tested by the RegExp.
+- `preserve: function (comment) { ... }` &mdash; a function that returns `true` to preserve the comment or `false` to strip it. The comment is invoked with a single argument, the string found between the comment syntax, `/**/`.
 
-### filter
-
-Type: `function`  
-Default: `undefined`
-
-A function that gets the comment contents and returns a boolean whether to strip the comment. If `true`, the comment is stripped. If `false`, the comment is preserved.
 
 ## CLI
 
@@ -76,13 +87,11 @@ $ strip-css-comments --help
     $ strip-css-comments < src/app.css --all
 ```
 
-
 ## Benchmark
 
 ```
 $ npm run bench
 ```
-
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -41,6 +41,26 @@ test(function (t) {
         strip('body{/*##foo##*//*foo*/}', {
                 filter: function(comment){return /^##foo##/.test(comment);}
         }) === 'body{/*foo*/}');
-
+    t.assert(
+        strip('body{/*##foo##*//*foo*/}', {
+                all: true,
+                filter: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*foo*/}');
+    t.assert(
+        strip('body{/*##foo##*//*!foo*/}', {
+                all: true,
+                filter: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*!foo*/}');
+    t.assert(
+        strip('body{/*!##foo##*//*foo*/}', {
+                all: true,
+                filter: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*!##foo##*//*foo*/}');
+    t.assert(
+        strip('body{/*!##foo##*//*foo*/}', {
+                all: true,
+                filter: function(comment){return /^!##foo##/.test(comment);}
+        }) === 'body{/*foo*/}');
+    
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -38,32 +38,32 @@ test(function (t) {
 
 	t.assert(strip(new Buffer('body{/*comment*/}')) === 'body{}');
 
-    t.assert(strip('body{/*##foo##*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
-    t.assert(strip('body{/*foo*/}', {preserve: /^##foo##/}) === 'body{}');
-    t.assert(strip('body{/*##foo##*//*foo*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
-    t.assert(strip('body{/*##foo##*//*!foo*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
-    t.assert(strip('body{/*!##foo##*//*foo*/}', {preserve: /^##foo##/}) === 'body{}');
+	t.assert(strip('body{/*##foo##*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
+	t.assert(strip('body{/*foo*/}', {preserve: /^##foo##/}) === 'body{}');
+	t.assert(strip('body{/*##foo##*//*foo*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
+	t.assert(strip('body{/*##foo##*//*!foo*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
+	t.assert(strip('body{/*!##foo##*//*foo*/}', {preserve: /^##foo##/}) === 'body{}');
 
-    t.assert(
-        strip('body{/*##foo##*/}', {
-                preserve: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*##foo##*/}');
-    t.assert(
-        strip('body{/*foo*/}', {
-                preserve: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{}');
-    t.assert(
-        strip('body{/*##foo##*//*foo*/}', {
-                preserve: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*##foo##*/}');
-    t.assert(
-        strip('body{/*##foo##*//*!foo*/}', {
-                preserve: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*##foo##*/}');
-    t.assert(
-        strip('body{/*!##foo##*//*foo*/}', {
-                preserve: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{}');
+	t.assert(
+		strip('body{/*##foo##*/}', {
+				preserve: function(comment){return /^##foo##/.test(comment);}
+		}) === 'body{/*##foo##*/}');
+	t.assert(
+		strip('body{/*foo*/}', {
+				preserve: function(comment){return /^##foo##/.test(comment);}
+		}) === 'body{}');
+	t.assert(
+		strip('body{/*##foo##*//*foo*/}', {
+				preserve: function(comment){return /^##foo##/.test(comment);}
+		}) === 'body{/*##foo##*/}');
+	t.assert(
+		strip('body{/*##foo##*//*!foo*/}', {
+				preserve: function(comment){return /^##foo##/.test(comment);}
+		}) === 'body{/*##foo##*/}');
+	t.assert(
+		strip('body{/*!##foo##*//*foo*/}', {
+				preserve: function(comment){return /^##foo##/.test(comment);}
+		}) === 'body{}');
 
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -29,5 +29,18 @@ test(function (t) {
 
 	t.assert(strip(new Buffer('body{/*comment*/}')) === 'body{}');
 
+    t.assert(
+        strip('body{/*##foo##*/}', {
+                filter: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{}');
+    t.assert(
+        strip('body{/*foo*/}', {
+                filter: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*foo*/}');
+    t.assert(
+        strip('body{/*##foo##*//*foo*/}', {
+                filter: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*foo*/}');
+
 	t.end();
 });

--- a/test.js
+++ b/test.js
@@ -20,47 +20,50 @@ test(function (t) {
 	t.assert(strip('body{/*!"\'\\"*/}') === 'body{/*!"\'\\"*/}');
 
 	t.assert(strip('/*!//comment*/body{}', {all: true}) === 'body{}');
-	t.assert(strip('body{/*!comment*/}', {all: true}) === 'body{}');
-	t.assert(strip('body{/*!\ncomment\n\\*/}', {all: true}) === 'body{}');
-	t.assert(strip('body{content: "\'/*!ad*/\' \\""}', {all: true}) === 'body{content: "\'/*!ad*/\' \\""}');
-	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}', {all: true}) === 'body{\r\n \n}');
-	t.assert(strip('body/*!foo*/{}', {all: true}) === 'body{}');
-	t.assert(strip('body{/*!"\'\\"*/}', {all: true}) === 'body{}');
+	t.assert(strip('/*!//comment*/body{}',  {all: true}) === 'body{}');
+	t.assert(strip('body{/*!comment*/}',  {all: true}) === 'body{}');
+	t.assert(strip('body{/*!\ncomment\n\\*/}',  {all: true}) === 'body{}');
+	t.assert(strip('body{content: "\'/*!ad*/\' \\""}',  {all: true}) === 'body{content: "\'/*!ad*/\' \\""}');
+	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}',  {all: true}) === 'body{\r\n \n}');
+	t.assert(strip('body/*!foo*/{}',  {all: true}) === 'body{}');
+	t.assert(strip('body{/*!"\'\\"*/}',  {all: true}) === 'body{}');
+
+	t.assert(strip('/*!//comment*/body{}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{/*!comment*/}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{/*!\ncomment\n\\*/}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{content: "\'/*!ad*/\' \\""}', {preserve: false}) === 'body{content: "\'/*!ad*/\' \\""}');
+	t.assert(strip('body{\r\n /*!\n\n\n\nfoo*/\n}', {preserve: false}) === 'body{\r\n \n}');
+	t.assert(strip('body/*!foo*/{}', {preserve: false}) === 'body{}');
+	t.assert(strip('body{/*!"\'\\"*/}', {preserve: false}) === 'body{}');
 
 	t.assert(strip(new Buffer('body{/*comment*/}')) === 'body{}');
 
+    t.assert(strip('body{/*##foo##*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
+    t.assert(strip('body{/*foo*/}', {preserve: /^##foo##/}) === 'body{}');
+    t.assert(strip('body{/*##foo##*//*foo*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
+    t.assert(strip('body{/*##foo##*//*!foo*/}', {preserve: /^##foo##/}) === 'body{/*##foo##*/}');
+    t.assert(strip('body{/*!##foo##*//*foo*/}', {preserve: /^##foo##/}) === 'body{}');
+
     t.assert(
         strip('body{/*##foo##*/}', {
-                filter: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{}');
+                preserve: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*##foo##*/}');
     t.assert(
         strip('body{/*foo*/}', {
-                filter: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*foo*/}');
+                preserve: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{}');
     t.assert(
         strip('body{/*##foo##*//*foo*/}', {
-                filter: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*foo*/}');
-    t.assert(
-        strip('body{/*##foo##*//*foo*/}', {
-                all: true,
-                filter: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*foo*/}');
+                preserve: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*##foo##*/}');
     t.assert(
         strip('body{/*##foo##*//*!foo*/}', {
-                all: true,
-                filter: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*!foo*/}');
+                preserve: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{/*##foo##*/}');
     t.assert(
         strip('body{/*!##foo##*//*foo*/}', {
-                all: true,
-                filter: function(comment){return /^##foo##/.test(comment);}
-        }) === 'body{/*!##foo##*//*foo*/}');
-    t.assert(
-        strip('body{/*!##foo##*//*foo*/}', {
-                all: true,
-                filter: function(comment){return /^!##foo##/.test(comment);}
-        }) === 'body{/*foo*/}');
-    
+                preserve: function(comment){return /^##foo##/.test(comment);}
+        }) === 'body{}');
+
 	t.end();
 });


### PR DESCRIPTION
In response to your most recent comment on [issue #10](https://github.com/sindresorhus/strip-css-comments/issues/10#issuecomment-118329158), this PR adds support for a filter option. The filter option is a function that "gets the comment contents and returns a boolean whether to strip the comment". If true, the comment is stripped. If false, the comment is preserved. This PR includes relevant tests and documentation.