### PR TITLE
Don't create new string to find /* and */

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,11 @@ module.exports = function (str, opts) {
 		}
 
 		// start /* type comment
-		if (!insideString && currentChar + str[i + 1] === '/*') {
+		if (!insideString && currentChar === '/' && str[i + 1] === '*') {
 			if (!preserve || preserve && str[i + 2] !== '!') {
 				// start skipping until we reach end of comment
 				for (var j = i + 2; j < str.length; j++) {
-					if (str[j] + str[j + 1] === '*/') {
+					if (str[j] === '*' && str[j + 1] === '/') {
 						break;
 					}
 				}


### PR DESCRIPTION
Improving performance (#1)

```
Before:
             74 op/s » strip CSS comments
After:
             155 op/s » strip CSS comments
```