### PR TITLE
Require Node.js 6 and clean up

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-sudo: false
 language: node_js
 node_js:
-  - '5'
-  - '4'
-  - '0.12'
-  - '0.10'
+  - '10'
+  - '8'
+  - '6'

--- a/bench.js
+++ b/bench.js
@@ -1,13 +1,14 @@
 'use strict';
 /* global bench */
-var fs = require('fs');
-var stripCssComments = require('./');
-var fixture = fs.readFileSync('fixture.css', 'utf8');
+const fs = require('fs');
+const stripCssComments = require('.');
 
-bench('strip CSS comments', function () {
+const fixture = fs.readFileSync('fixture.css', 'utf8');
+
+bench('strip CSS comments', () => {
 	stripCssComments(fixture);
 });
 
-bench('preserve option', function () {
+bench('preserve option', () => {
 	stripCssComments(fixture, {preserve: /^!/});
 });

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 'use strict';
-var isRegExp = require('is-regexp');
+const isRegExp = require('is-regexp');
 
 module.exports = function (str, opts) {
 	str = str.toString();
 	opts = opts || {};
 
-	var preserveFilter;
-	var comment = '';
-	var currentChar = '';
-	var insideString = false;
-	var preserveImportant = !(opts.preserve === false || opts.all === true);
-	var ret = '';
+	let preserveFilter;
+	let comment = '';
+	let currentChar = '';
+	let insideString = false;
+	let preserveImportant = !(opts.preserve === false || opts.all === true);
+	let ret = '';
 
 	if (typeof opts.preserve === 'function') {
 		preserveImportant = false;
@@ -22,7 +22,7 @@ module.exports = function (str, opts) {
 		};
 	}
 
-	for (var i = 0; i < str.length; i++) {
+	for (let i = 0; i < str.length; i++) {
 		currentChar = str[i];
 
 		if (str[i - 1] !== '\\') {
@@ -35,18 +35,18 @@ module.exports = function (str, opts) {
 			}
 		}
 
-		// find beginning of /* type comment
+		// Find beginning of /* type comment
 		if (!insideString && currentChar === '/' && str[i + 1] === '*') {
 			// ignore important comment when configured to preserve comments using important syntax: /*!
 			if (!(preserveImportant && str[i + 2] === '!')) {
-				var j = i + 2;
+				let j = i + 2;
 
-				// iterate over comment
+				// Iterate over comment
 				for (; j < str.length; j++) {
-					// find end of comment
+					// Find end of comment
 					if (str[j] === '*' && str[j + 1] === '/') {
 						if (preserveFilter) {
-							// evaluate comment text
+							// Evaluate comment text
 							ret = preserveFilter(comment) ? ret + ('/*' + comment + '*/') : ret;
 							comment = '';
 						}
@@ -54,13 +54,13 @@ module.exports = function (str, opts) {
 						break;
 					}
 
-					// store comment text to be evaluated by the filter when the end of the comment is reached
+					// Store comment text to be evaluated by the filter when the end of the comment is reached
 					if (preserveFilter) {
 						comment += str[j];
 					}
 				}
 
-				// resume iteration over CSS string from the end of the comment
+				// Resume iteration over CSS string from the end of the comment
 				i = j + 1;
 
 				continue;

--- a/license
+++ b/license
@@ -1,21 +1,9 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,43 +1,43 @@
 {
-  "name": "strip-css-comments",
-  "version": "3.0.0",
-  "description": "Strip comments from CSS",
-  "license": "MIT",
-  "repository": "sindresorhus/strip-css-comments",
-  "author": {
-    "name": "Sindre Sorhus",
-    "email": "sindresorhus@gmail.com",
-    "url": "sindresorhus.com"
-  },
-  "engines": {
-    "node": ">=0.10.0"
-  },
-  "scripts": {
-    "test": "xo && ava",
-    "bench": "matcha bench.js"
-  },
-  "files": [
-    "index.js"
-  ],
-  "keywords": [
-    "css",
-    "style",
-    "stylesheet",
-    "strip",
-    "remove",
-    "delete",
-    "trim",
-    "comments",
-    "preprocess",
-    "transform",
-    "string"
-  ],
-  "dependencies": {
-    "is-regexp": "^1.0.0"
-  },
-  "devDependencies": {
-    "ava": "*",
-    "matcha": "^0.7.0",
-    "xo": "*"
-  }
+	"name": "strip-css-comments",
+	"version": "3.0.0",
+	"description": "Strip comments from CSS",
+	"license": "MIT",
+	"repository": "sindresorhus/strip-css-comments",
+	"author": {
+		"name": "Sindre Sorhus",
+		"email": "sindresorhus@gmail.com",
+		"url": "sindresorhus.com"
+	},
+	"engines": {
+		"node": ">=6"
+	},
+	"scripts": {
+		"test": "xo && ava",
+		"bench": "matcha bench.js"
+	},
+	"files": [
+		"index.js"
+	],
+	"keywords": [
+		"css",
+		"style",
+		"stylesheet",
+		"strip",
+		"remove",
+		"delete",
+		"trim",
+		"comments",
+		"preprocess",
+		"transform",
+		"string"
+	],
+	"dependencies": {
+		"is-regexp": "^2.0.0"
+	},
+	"devDependencies": {
+		"ava": "*",
+		"matcha": "^0.7.0",
+		"xo": "*"
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Also available as a [gulp](https://github.com/sindresorhus/gulp-strip-css-commen
 ## Usage
 
 ```
-$ npm install --save strip-css-comments
+$ npm install strip-css-comments
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import m from '.';
 
-test(t => {
+test('main', t => {
 	t.is(m('/*//comment*/body{}'), 'body{}');
 	t.is(m('body{/*comment*/}'), 'body{}');
 	t.is(m('body{/*\ncomment\n\\*/}'), 'body{}');

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test(t => {
 	t.is(m('/*//comment*/body{}'), 'body{}');
@@ -35,7 +35,7 @@ test(t => {
 	t.is(m('body/*!foo*/{}', {preserve: false}), 'body{}');
 	t.is(m('body{/*!"\'\\"*/}', {preserve: false}), 'body{}');
 
-	t.is(m(new Buffer('body{/*comment*/}')), 'body{}');
+	t.is(m(Buffer.from('body{/*comment*/}')), 'body{}');
 
 	t.is(m('body{/*##foo##*/}', {preserve: /^##foo##/}), 'body{/*##foo##*/}');
 	t.is(m('body{/*foo*/}', {preserve: /^##foo##/}), 'body{}');
@@ -45,31 +45,31 @@ test(t => {
 
 	t.is(
 		m('body{/*##foo##*/}', {
-			preserve: comment => /^##foo##/.test(comment)
+			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{/*##foo##*/}'
 	);
 
 	t.is(
 		m('body{/*foo*/}', {
-			preserve: comment => /^##foo##/.test(comment)
+			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{}'
 	);
 
 	t.is(
 		m('body{/*##foo##*//*foo*/}', {
-			preserve: comment => /^##foo##/.test(comment)
+			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{/*##foo##*/}'
 	);
 
 	t.is(
 		m('body{/*##foo##*//*!foo*/}', {
-			preserve: comment => /^##foo##/.test(comment)
+			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{/*##foo##*/}'
 	);
 
 	t.is(
 		m('body{/*!##foo##*//*foo*/}', {
-			preserve: comment => /^##foo##/.test(comment)
+			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{}'
 	);
 });


### PR DESCRIPTION
Cleans up and modernizes a few things. For example, updating Travis CI, requiring Node.js v6, and using tabs in `package.json`. Includes XO fixes from https://github.com/sindresorhus/strip-css-comments/pull/16.

Closes #16 