### PR TITLE
Implement `whitespace` option

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -12,3 +12,7 @@ bench('strip CSS comments', () => {
 bench('preserve option', () => {
 	stripCssComments(fixture, {preserve: /^!/});
 });
+
+bench('whitespace option', () => {
+	stripCssComments(fixture, {whitespace: false});
+});

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const isRegExp = require('is-regexp');
 module.exports = (input, options = {}) => {
 	let preserveImportant = !(options.preserve === false || options.all === true);
 
+	const stripWhitespace = options.whitespace === false;
+
 	let preserveFilter;
 	if (typeof options.preserve === 'function') {
 		preserveImportant = false;
@@ -41,10 +43,16 @@ module.exports = (input, options = {}) => {
 				for (; j < input.length; j++) {
 					// Find end of comment
 					if (input[j] === '*' && input[j + 1] === '/') {
-						if (preserveFilter) {
+						if (preserveFilter && preserveFilter(comment)) {
 							// Evaluate comment text
-							returnValue = preserveFilter(comment) ? returnValue + ('/*' + comment + '*/') : returnValue;
+							returnValue += '/*' + comment + '*/';
 							comment = '';
+						} else if (stripWhitespace) {
+							if (input[j + 2] === '\n') {
+								j++;
+							} else if (input[j + 2] + input[j + 3] === '\r\n') {
+								j += 2;
+							}
 						}
 
 						break;

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,13 @@ Default: `true`
 - `RegExp` - Preserve comments where the comment body matches a regular expression.
 - `Function` - Preserve comments for which a function returns `true`. The function is called on each comment, gets the comment body as the first argument, and is expected to return a boolean of whether to preserve the comment.
 
+### whitespace
+
+Type: `boolean`<br>
+Default: `true`
+
+Replace comments with whitespace instead of stripping them entirely.
+
 
 ## Benchmark
 

--- a/test.js
+++ b/test.js
@@ -70,10 +70,11 @@ test('main', t => {
 			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{}'
 	);
-});
 
-test.failing('strips trailing comment newline', t => {
-	t.is(m('/* foo */\n\nbody{}'), '\nbody{}');
-	t.is(m('/* foo */\r\n\r\nbody{}'), '\nbody{}');
-	t.is(m('/*! foo */\r\n\r\nbody{}'), '/*! foo */\r\n\r\nbody{}');
+	t.is(m('/* foo */\n\nbody{}', {whitespace: false}), '\nbody{}');
+	t.is(m('/* foo */\r\n\r\nbody{}', {whitespace: false}), '\r\nbody{}');
+	t.is(m('/*! foo */\r\n\r\nbody{}', {whitespace: false}), '/*! foo */\r\n\r\nbody{}');
+
+	t.is(m('/*##foo##*/\nbody{}', {preserve: /^##foo##/, whitespace: false}), '/*##foo##*/\nbody{}');
+	t.is(m('/*##foo##*/\r\nbody{}', {preserve: /^##foo##/, whitespace: false}), '/*##foo##*/\r\nbody{}');
 });


### PR DESCRIPTION
Implements a `whitespace` option like [strip-json-comment’s](https://github.com/sindresorhus/strip-json-comments#whitespace). Defaults to `true` to preserve the old behavior. If set to `false`, the newline (either `\n` or `\r\n`) following a comment is removed.

See https://github.com/sindresorhus/strip-css-comments/issues/14#issuecomment-277543740. Closes #14.