### PR TITLE
Ignore string separator in important comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,10 +42,10 @@ module.exports = (cssString, options = {}) => {
 				// Find end of comment
 				if (cssString[j] === '*' && cssString[j + 1] === '/') {
 					if (preserveImportant && isImportantComment) {
-						returnValue += ('/*' + comment + '*/');
+						returnValue += `/*${comment}*/`;
 					} else if (preserveFilter) {
 						// Evaluate comment text
-						returnValue = preserveFilter(comment) ? returnValue + ('/*' + comment + '*/') : returnValue;
+						returnValue = preserveFilter(comment) ? returnValue + `/*${comment}*/` : returnValue;
 					}
 
 					comment = '';

--- a/index.js
+++ b/index.js
@@ -34,33 +34,33 @@ module.exports = (cssString, options = {}) => {
 		// Find beginning of `/*` type comment
 		if (!isInsideString && currentCharacter === '/' && cssString[i + 1] === '*') {
 			// Ignore important comment when configured to preserve comments using important syntax: /*!
-			if (!(preserveImportant && cssString[i + 2] === '!')) {
-				let j = i + 2;
+			const isImportantComment = cssString[i + 2] === '!';
+			let j = i + 2;
 
-				// Iterate over comment
-				for (; j < cssString.length; j++) {
-					// Find end of comment
-					if (cssString[j] === '*' && cssString[j + 1] === '/') {
-						if (preserveFilter) {
-							// Evaluate comment text
-							returnValue = preserveFilter(comment) ? returnValue + ('/*' + comment + '*/') : returnValue;
-							comment = '';
-						}
-
-						break;
+			// Iterate over comment
+			for (; j < cssString.length; j++) {
+				// Find end of comment
+				if (cssString[j] === '*' && cssString[j + 1] === '/') {
+					if (preserveImportant && isImportantComment) {
+						returnValue += ('/*' + comment + '*/');
+					} else if (preserveFilter) {
+						// Evaluate comment text
+						returnValue = preserveFilter(comment) ? returnValue + ('/*' + comment + '*/') : returnValue;
 					}
 
-					// Store comment text to be evaluated by the filter when the end of the comment is reached
-					if (preserveFilter) {
-						comment += cssString[j];
-					}
+					comment = '';
+
+					break;
 				}
 
-				// Resume iteration over CSS string from the end of the comment
-				i = j + 1;
-
-				continue;
+				// Store comment text
+				comment += cssString[j];
 			}
+
+			// Resume iteration over CSS string from the end of the comment
+			i = j + 1;
+
+			continue;
 		}
 
 		returnValue += currentCharacter;

--- a/test.js
+++ b/test.js
@@ -8,41 +8,57 @@ test('main', t => {
 	t.is(stripCssComments('body{content: "\'/*ad*/\' \\""}'), 'body{content: "\'/*ad*/\' \\""}');
 	t.is(stripCssComments('body{\r\n /*\n\n\n\nfoo*/\n}'), 'body{\r\n \n}');
 	t.is(stripCssComments('body/*foo*/{}'), 'body{}');
+	t.is(stripCssComments('body{/*"*/}'), 'body{}');
+	t.is(stripCssComments('body{/*\'*/}'), 'body{}');
 	t.is(stripCssComments('body{/*"\'\\"*/}'), 'body{}');
+	t.is(stripCssComments('body{/*"\'"\'*/}'), 'body{}');
 
 	t.is(stripCssComments('/*!//comment*/body{}'), '/*!//comment*/body{}');
+	t.is(stripCssComments('/*!//"comment*/body{/*//comment*/}'), '/*!//"comment*/body{}');
+	t.is(stripCssComments('/*!//\'comment*/body{/*//comment*/}'), '/*!//\'comment*/body{}');
 	t.is(stripCssComments('body{/*!comment*/}'), 'body{/*!comment*/}');
 	t.is(stripCssComments('body{/*!\ncomment\n\\*/}'), 'body{/*!\ncomment\n\\*/}');
 	t.is(stripCssComments('body{content: "\'/*!ad*/\' \\""}'), 'body{content: "\'/*!ad*/\' \\""}');
 	t.is(stripCssComments('body{\r\n /*!\n\n\n\nfoo*/\n}'), 'body{\r\n /*!\n\n\n\nfoo*/\n}');
 	t.is(stripCssComments('body/*!foo*/{}'), 'body/*!foo*/{}');
+	t.is(stripCssComments('body{/*!"*/}/*foo*/'), 'body{/*!"*/}');
+	t.is(stripCssComments('body{/*!\'*/}/*foo*/'), 'body{/*!\'*/}');
 	t.is(stripCssComments('body{/*!"\'\\"*/}'), 'body{/*!"\'\\"*/}');
-	t.is(stripCssComments('/*!//i"m comment*/body{/*another comment*/}'), '/*!//i"m comment*/body{}');
+	t.is(stripCssComments('body{/*!"\'"\'*/}'), 'body{/*!"\'"\'*/}');
 
 	t.is(stripCssComments('/*!//comment*/body{}', {all: true}), 'body{}');
 	t.is(stripCssComments('/*!//comment*/body{}', {all: true}), 'body{}');
+	t.is(stripCssComments('/*!//"comment*/body{}', {all: true}), 'body{}');
+	t.is(stripCssComments('/*!//\'comment*/body{}', {all: true}), 'body{}');
 	t.is(stripCssComments('body{/*!comment*/}', {all: true}), 'body{}');
 	t.is(stripCssComments('body{/*!\ncomment\n\\*/}', {all: true}), 'body{}');
 	t.is(stripCssComments('body{content: "\'/*!ad*/\' \\""}', {all: true}), 'body{content: "\'/*!ad*/\' \\""}');
 	t.is(stripCssComments('body{\r\n /*!\n\n\n\nfoo*/\n}', {all: true}), 'body{\r\n \n}');
 	t.is(stripCssComments('body/*!foo*/{}', {all: true}), 'body{}');
+	t.is(stripCssComments('body{/*!"*/}/*foo*/', {all: true}), 'body{}');
+	t.is(stripCssComments('body{/*!\'*/}/*foo*/', {all: true}), 'body{}');
 	t.is(stripCssComments('body{/*!"\'\\"*/}', {all: true}), 'body{}');
-	t.is(stripCssComments('/*!//i"m comment*/body{/*another comment*/}', {all: true}), 'body{}');
+	t.is(stripCssComments('body{/*!"\'"\'*/}', {all: true}), 'body{}');
 
 	t.is(stripCssComments('/*!//comment*/body{}', {preserve: false}), 'body{}');
+	t.is(stripCssComments('/*!//"comment*/body{}', {preserve: false}), 'body{}');
+	t.is(stripCssComments('/*!//\'comment*/body{}', {preserve: false}), 'body{}');
 	t.is(stripCssComments('body{/*!comment*/}', {preserve: false}), 'body{}');
 	t.is(stripCssComments('body{/*!\ncomment\n\\*/}', {preserve: false}), 'body{}');
 	t.is(stripCssComments('body{content: "\'/*!ad*/\' \\""}', {preserve: false}), 'body{content: "\'/*!ad*/\' \\""}');
 	t.is(stripCssComments('body{\r\n /*!\n\n\n\nfoo*/\n}', {preserve: false}), 'body{\r\n \n}');
 	t.is(stripCssComments('body/*!foo*/{}', {preserve: false}), 'body{}');
+	t.is(stripCssComments('body{/*!"*/}/*foo*/', {preserve: false}), 'body{}');
+	t.is(stripCssComments('body{/*!\'*/}/*foo*/', {preserve: false}), 'body{}');
 	t.is(stripCssComments('body{/*!"\'\\"*/}', {preserve: false}), 'body{}');
-	t.is(stripCssComments('/*!//i"m comment*/body{/*another comment*/}', {preserve: false}), 'body{}');
+	t.is(stripCssComments('body{/*!"\'"\'*/}', {preserve: false}), 'body{}');
 
 	t.is(stripCssComments('body{/*##foo##*/}', {preserve: /^##foo##/}), 'body{/*##foo##*/}');
 	t.is(stripCssComments('body{/*foo*/}', {preserve: /^##foo##/}), 'body{}');
 	t.is(stripCssComments('body{/*##foo##*//*foo*/}', {preserve: /^##foo##/}), 'body{/*##foo##*/}');
 	t.is(stripCssComments('body{/*##foo##*//*!foo*/}', {preserve: /^##foo##/}), 'body{/*##foo##*/}');
 	t.is(stripCssComments('body{/*!##foo##*//*foo*/}', {preserve: /^##foo##/}), 'body{}');
+	t.is(stripCssComments('body{/*!##foo*//*foo*/}', {preserve: /foo$/}), 'body{/*!##foo*//*foo*/}');
 
 	t.is(
 		stripCssComments('body{/*##foo##*/}', {
@@ -73,6 +89,11 @@ test('main', t => {
 			preserve: comment => comment.startsWith('##foo##')
 		}), 'body{}'
 	);
+
+	t.is(
+		stripCssComments('body{/*!##foo*//*foo*/}', {
+			preserve: comment => comment.endsWith('foo')
+		}), 'body{/*!##foo*//*foo*/}');
 });
 
 test.failing('strips trailing comment newline', t => {

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ test('main', t => {
 	t.is(stripCssComments('body{\r\n /*!\n\n\n\nfoo*/\n}'), 'body{\r\n /*!\n\n\n\nfoo*/\n}');
 	t.is(stripCssComments('body/*!foo*/{}'), 'body/*!foo*/{}');
 	t.is(stripCssComments('body{/*!"\'\\"*/}'), 'body{/*!"\'\\"*/}');
+	t.is(stripCssComments('/*!//i"m comment*/body{/*another comment*/}'), '/*!//i"m comment*/body{}');
 
 	t.is(stripCssComments('/*!//comment*/body{}', {all: true}), 'body{}');
 	t.is(stripCssComments('/*!//comment*/body{}', {all: true}), 'body{}');
@@ -26,6 +27,7 @@ test('main', t => {
 	t.is(stripCssComments('body{\r\n /*!\n\n\n\nfoo*/\n}', {all: true}), 'body{\r\n \n}');
 	t.is(stripCssComments('body/*!foo*/{}', {all: true}), 'body{}');
 	t.is(stripCssComments('body{/*!"\'\\"*/}', {all: true}), 'body{}');
+	t.is(stripCssComments('/*!//i"m comment*/body{/*another comment*/}', {all: true}), 'body{}');
 
 	t.is(stripCssComments('/*!//comment*/body{}', {preserve: false}), 'body{}');
 	t.is(stripCssComments('body{/*!comment*/}', {preserve: false}), 'body{}');
@@ -34,6 +36,7 @@ test('main', t => {
 	t.is(stripCssComments('body{\r\n /*!\n\n\n\nfoo*/\n}', {preserve: false}), 'body{\r\n \n}');
 	t.is(stripCssComments('body/*!foo*/{}', {preserve: false}), 'body{}');
 	t.is(stripCssComments('body{/*!"\'\\"*/}', {preserve: false}), 'body{}');
+	t.is(stripCssComments('/*!//i"m comment*/body{/*another comment*/}', {preserve: false}), 'body{}');
 
 	t.is(stripCssComments('body{/*##foo##*/}', {preserve: /^##foo##/}), 'body{/*##foo##*/}');
 	t.is(stripCssComments('body{/*foo*/}', {preserve: /^##foo##/}), 'body{}');

--- a/test.js
+++ b/test.js
@@ -93,7 +93,9 @@ test('main', t => {
 	t.is(
 		stripCssComments('body{/*!##foo*//*foo*/}', {
 			preserve: comment => comment.endsWith('foo')
-		}), 'body{/*!##foo*//*foo*/}');
+		}),
+		'body{/*!##foo*//*foo*/}'
+	);
 });
 
 test.failing('strips trailing comment newline', t => {


### PR DESCRIPTION
If important comment contains `"` or `'`, It might be trigger a bug.

Pass code below as input to strip-css-comments, it can not remove normal comment.
```css
/*!i'm important*/

body {
  /* body style */
  color: #666;
}
```